### PR TITLE
fix: fixes assets:cp script bug for linux

### DIFF
--- a/plugins/markdown/revealjs/templates/init/package.json
+++ b/plugins/markdown/revealjs/templates/init/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"scripts": {
 		"slides:assets:mkdirp": "shx mkdir -p html/assets",
-		"slides:assets:cp": "shx cp -PR slides/assets/ html/assets/",
+		"slides:assets:cp": "shx cp -PR slides/assets/* html/assets/",
 		"slides:assets": "run-s slides:assets:mkdirp  slides:assets:cp",
 		"slides:build:pandoc": "pandoc --section-divs -s -t revealjs slides/*.md -o html/index.html --verbose --slide-level=1 --from markdown-yaml_metadata_block --variable theme='beige'",
 		"slides:build": "run-s slides:assets  slides:build:pandoc",


### PR DESCRIPTION
Fixes issue where the cp command on Linux would create a file called 'assets' rather than copying files from slides/assets to html/assets.

This solutions is tested with the following platforms:

Ubuntu 20.04
    Node v14.15.4
    Npm v6.14.10
    Pandoc v2.11.3.2
    
Mac OS
    Node v10.23.1
    Npm v6.14.10
    Pandoc v2.11.3.2

Windows 10
    Node v14.15.4
    Npm v6.14.10
    Pandoc v2.11.3.2

fixes: #16